### PR TITLE
针对2021.2版本引擎中 System.Type 的特性进行优化

### DIFF
--- a/Assets/Examples/Editor/PuertsFilter.cs
+++ b/Assets/Examples/Editor/PuertsFilter.cs
@@ -76,6 +76,8 @@ public class PuertsFilter : Editor
                 new List<string>(){"System.IO.File", "GetAccessControl", "System.String"},
                 new List<string>(){"System.IO.File", "GetAccessControl", "System.String", "System.Security.AccessControl.AccessControlSections"},
                 new List<string>(){"System.IO.File", "Create", "System.String", "System.Int32", "System.IO.FileOptions", "System.Security.AccessControl.FileSecurity"},
+                new List<string>(){"System.Type", "MakeGenericSignatureType", "System.Type", "System.Type[]"},
+                new List<string>(){"System.Type", "IsCollectible"},
             };
         }
     }


### PR DESCRIPTION
增加对  System.Type 中以下 API 的识别：
        System.Type.MakeGenericSignatureType
        System.Type.IsCollectible

可解决的问题：
Assets\Gen\System_Type_Wrap.cs(1604,50): error CS0117: 'Type' does not contain a definition for 'MakeGenericSignatureType'
Assets\Gen\System_Type_Wrap.cs(1615,50): error CS0117: 'Type' does not contain a definition for 'MakeGenericSignatureType'
Assets\Gen\System_Type_Wrap.cs(2600,34): error CS1061: 'Type' does not contain a definition for 'IsCollectible' and no accessible extension method 'IsCollectible' accepting a first argument of type 'Type' could be found (are you missing a using directive or an assembly reference?)

修正前的测试结果：
Unity 2021.2.x, .Net Standard 2.0（存在问题）
Unity 2021.2.x, .Net Standard 2.1（存在问题）

修正后的测试结果：
Unity 2021.2.x, .Net Standard 2.0（可编译通过）
Unity 2021.2.x, .Net Standard 2.1（可编译通过）